### PR TITLE
Add repository scan mode with SARIF output, scanner and SARIF generation; update CLI, action inputs, and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,9 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
   checks: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   commit-validation:
@@ -45,23 +45,16 @@ jobs:
           poetry config virtualenvs.in-project true
           poetry install --with dev
       - name: Run tests with coverage
-        continue-on-error: true
         run: |
           poetry run pytest --cov=network_reputation_check --cov-report=xml --cov-report=term
-      - name: Generate and commit coverage badge
-
+      - name: Generate coverage badge
         run: |
           poetry run genbadge coverage -i coverage.xml -o coverage.svg
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global commit.gpgsign false
-          git add coverage.svg
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: Update coverage badge [ci skip]" --author="github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-            git push
-          else
-            echo "No coverage changes to commit"
-          fi
+      - name: Upload coverage badge artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-badge
+          path: coverage.svg
 
   lint:
     runs-on: ubuntu-latest
@@ -83,20 +76,9 @@ jobs:
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
           poetry install --with dev
-      - name: Run pre-commit hooks and commit changes
-        continue-on-error: true
+      - name: Run pre-commit hooks
         run: |
-          poetry run pre-commit run --all-files || echo "Pre-commit hooks modified files."
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global commit.gpgsign false  # Disable signing for automated commits
-          git add .
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: Apply pre-commit fixes [ci skip]" --author="github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-            git push
-          else
-            echo "No changes to commit"
-          fi
+          poetry run pre-commit run --all-files
 
 
   validate-docker:

--- a/.github/workflows/run-reputation-check.yaml
+++ b/.github/workflows/run-reputation-check.yaml
@@ -4,14 +4,26 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'Target IP or domain'
-        required: true
+        description: 'Target IP/domain/CIDR (optional when scan-path is provided)'
+        required: false
       source:
         description: 'Source to use (virustotal, urlscan)'
         required: true
       api-key:
         description: 'API key for source (required for VirusTotal, optional for urlscan.io)'
         required: false
+      scan-path:
+        description: 'Optional repository path to recursively scan for indicators'
+        required: false
+        default: ''
+      sarif-file:
+        description: 'Optional SARIF output path to upload into Code Scanning'
+        required: false
+        default: 'network-reputation.sarif'
+
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   reputation-check:
@@ -24,3 +36,10 @@ jobs:
           target: ${{ github.event.inputs.target }}
           source: ${{ github.event.inputs.source }}
           api-key: ${{ github.event.inputs.api-key }}
+          scan-path: ${{ github.event.inputs.scan-path }}
+          sarif-file: ${{ github.event.inputs.sarif-file }}
+      - name: Upload SARIF to Code Scanning
+        if: ${{ github.event.inputs.sarif-file != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ github.event.inputs.sarif-file }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A GitHub Action and CLI tool to check the reputation of IPs, domains, or CIDR bl
 ## ✅ Features
 - Click-powered CLI
 - Supports one source per run
+- Repository scanning mode (`--scan-path`) to auto-discover IPs, domains, and CIDRs
+- SARIF export (`--sarif-file`) for GitHub Code Scanning and PR annotations
 - Works as a Docker-based GitHub Action
 - Clean, pluggable design with tests
 
@@ -26,13 +28,19 @@ A GitHub Action and CLI tool to check the reputation of IPs, domains, or CIDR bl
 
 ```bash
 poetry run reputation-check <target> --source <source> [--api-key YOUR_KEY] [--output-file output.json]
+
+# Scan a repository and emit SARIF for PR code scanning
+poetry run reputation-check --source virustotal --api-key "$VT_API_KEY" --scan-path . --sarif-file results.sarif
 ```
 
 ### CLI Parameters
-- `target` (required): The IP, domain, or CIDR block to check.
+- `target` (required unless `--scan-path` is used): The IP, domain, or CIDR block to check.
 - `--source` (required): The source to use for the reputation check (e.g., `virustotal`, `urlscan`).
 - `--api-key` (optional): The API key for the selected source. Can also be set via environment variables (`VT_API_KEY` for VirusTotal, `URLSCAN_API_KEY` for urlscan.io).
 - `--output-file` (optional): Path to save the raw JSON result.
+- `--scan-path` (optional): Recursively scan a codebase for public indicators and check each one (filters private/reserved IP space and local/internal domains like `.local`/`.internal`).
+- `--sarif-file` (optional): Path to save SARIF output for GitHub code scanning/PR annotations.
+> Security note: scan mode normalizes extracted tokens, skips large files, and escapes workflow annotations to prevent CRLF/workflow-command injection issues.
 
 ## 🚀 Usage (GitHub Actions)
 
@@ -40,15 +48,24 @@ poetry run reputation-check <target> --source <source> [--api-key YOUR_KEY] [--o
 - name: Run Network Reputation Check
   uses: ig596/network-reputation-check-action@main
   with:
-    target: "example.com"
     source: "virustotal"
     api-key: "${{ secrets.VT_API_KEY }}"
+    scan-path: "."
+    sarif-file: "network-reputation.sarif"
+
+- name: Upload SARIF to GitHub Code Scanning
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: "network-reputation.sarif"
 ```
 
 ### GitHub Action Parameters
-- `target` (required): The IP, domain, or CIDR block to check.
+- `target` (required unless `--scan-path` is used): The IP, domain, or CIDR block to check.
 - `source` (required): The source to use for the reputation check (e.g., `virustotal`, `urlscan`).
 - `api-key` (optional): The API key for the selected source. Can be passed via GitHub Secrets.
+- `scan-path` (optional): Recursively scan a repository path and evaluate all discovered indicators.
+- `sarif-file` (optional): Write SARIF with file/line locations so PR/code-scanning annotations show where indicators were found.
+- `output-file` (optional): Write raw JSON with per-indicator findings.
 
 ## 📦 Supported Sources
 - VirusTotal

--- a/action.yml
+++ b/action.yml
@@ -7,13 +7,22 @@ branding:
 
 inputs:
   target:
-    description: 'Target IP, domain, or CIDR to check.'
-    required: true
+    description: 'Target IP, domain, or CIDR to check (optional when scan-path is provided).'
+    required: false
   source:
     description: 'Source to use for reputation check (virustotal, urlscan).'
     required: true
   api-key:
     description: 'API key for the selected source (if required).'
+    required: false
+  scan-path:
+    description: 'Recursively scan this path for indicators and evaluate all discovered items.'
+    required: false
+  sarif-file:
+    description: 'Path to write SARIF output. Include this in upload-sarif/code scanning workflow steps.'
+    required: false
+  output-file:
+    description: 'Path to write raw JSON output.'
     required: false
 
 runs:
@@ -23,8 +32,14 @@ runs:
     GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
     GITHUB_WORKSPACE: ${{ env.GITHUB_WORKSPACE }}
   args:
-    - ${{ inputs.target }}
+    - ${{ inputs.target || '' }}
     - --source
     - ${{ inputs.source }}
     - ${{ inputs.api-key && '--api-key' }}
     - ${{ inputs.api-key || '' }}
+    - ${{ inputs.scan-path && '--scan-path' }}
+    - ${{ inputs.scan-path || '' }}
+    - ${{ inputs.sarif-file && '--sarif-file' }}
+    - ${{ inputs.sarif-file || '' }}
+    - ${{ inputs.output-file && '--output-file' }}
+    - ${{ inputs.output-file || '' }}

--- a/network_reputation_check/main.py
+++ b/network_reputation_check/main.py
@@ -17,6 +17,8 @@ import click
 from network_reputation_check.checks import get_all_checks
 from network_reputation_check.gh_summary import write_summary
 from network_reputation_check.renderers import render_markdown, render_terminal
+from network_reputation_check.sarif import build_sarif_run, classify_level
+from network_reputation_check.scanner import discover_indicators
 
 
 # --------------------------------------------------------------------------- #
@@ -27,13 +29,47 @@ def in_github_actions() -> bool:
     return os.getenv("GITHUB_ACTIONS", "").lower() == "true"
 
 
+def emit_annotation(level: str, file_path: str, line: int, message: str) -> None:
+    """Emit a GitHub Actions workflow annotation if applicable."""
+    if not in_github_actions():
+        return
+
+    if level == "error":
+        annotation_type = "error"
+    elif level == "warning":
+        annotation_type = "warning"
+    else:
+        annotation_type = "notice"
+
+    safe_file_path = _escape_workflow_command_value(file_path)
+    safe_message = _escape_workflow_command_value(message)
+    click.echo(f"::{annotation_type} file={safe_file_path},line={line}::{safe_message}")
+
+
+def _escape_workflow_command_value(value: str) -> str:
+    """Escape workflow command values to prevent command injection."""
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def sanitize_target(value: str | None) -> str | None:
+    """Sanitize user-provided target input."""
+    if value is None:
+        return None
+    cleaned = value.strip()
+    if any(ch in cleaned for ch in ("\r", "\n", "\t")):
+        msg = "Error: Target contains invalid control characters."
+        raise click.BadParameter(msg)
+    return cleaned
+
+
 # --------------------------------------------------------------------------- #
 # CLI
 # --------------------------------------------------------------------------- #
 logger = logging.getLogger(__name__)
 
+
 @click.command()
-@click.argument("target", required=True)
+@click.argument("target", required=False)
 @click.option(
     "--source",
     required=True,
@@ -50,27 +86,37 @@ logger = logging.getLogger(__name__)
     type=click.Path(writable=True),
     help="Write raw JSON result to this file.",
 )
-def cli(target: str, source: str, api_key: str | None, output_file: Path | None) -> None:
-    """Look up TARGET (IP or domain) in the specified source.
-
-    • Prints a human-friendly terminal report.
-    • Automatically appends a Markdown summary to GITHUB_STEP_SUMMARY
-      when running inside GitHub Actions.
-    • Exits 1 if any malicious or suspicious detections are present.
-    """
+@click.option(
+    "--scan-path",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Scan a repository path for indicators and run checks on all discovered items.",
+)
+@click.option(
+    "--sarif-file",
+    type=click.Path(writable=True, path_type=Path),
+    help="Write SARIF results to this file (recommended for PR code scanning annotations).",
+)
+def cli(  # noqa: C901, PLR0912, PLR0913, PLR0915
+    target: str | None,
+    source: str,
+    api_key: str | None,
+    output_file: Path | None,
+    scan_path: Path | None,
+    sarif_file: Path | None,
+) -> None:
+    """Run a single-target check or a repository scan in CI-friendly mode."""
     error_messages = {
-        "missing_target": "Error: Target is required.",
+        "missing_target": "Error: Target is required unless --scan-path is provided.",
         "missing_source": "Error: Source is required.",
         "unsupported_source": lambda s, keys: f"Error: Unsupported source '{s}'. Supported sources: {', '.join(keys)}.",
         "missing_api_key": "Error: VirusTotal requires an API key.",
     }
 
-    if not target:
-        click.echo(error_messages["missing_target"], err=True)
-        raise click.BadParameter(error_messages["missing_target"])
     if not source:
         click.echo(error_messages["missing_source"], err=True)
         raise click.BadParameter(error_messages["missing_source"])
+
+    target = sanitize_target(target)
 
     checks: dict[str, Any] = get_all_checks()
     if source not in checks:
@@ -84,7 +130,63 @@ def cli(target: str, source: str, api_key: str | None, output_file: Path | None)
         sys.exit(1)
 
     check = checks[source]
-    result: dict[str, Any] = check.run(target, api_key=api_key or "")
+
+    if scan_path:
+        candidates = discover_indicators(scan_path)
+        if not candidates:
+            click.echo("No scanable indicators found.")
+            if sarif_file:
+                sarif_payload = build_sarif_run(source, [])
+                with sarif_file.open("w", encoding="utf-8") as fp:
+                    json.dump(sarif_payload, fp, indent=2)
+            sys.exit(0)
+
+        scanned: list[tuple[Any, dict[str, Any]]] = []
+        failure = False
+        for candidate in candidates:
+            result: dict[str, Any] = check.run(candidate.value, api_key=api_key or "")
+            scanned.append((candidate, result))
+
+            level = "warning" if result.get("error") else classify_level(result)
+            if level == "error":
+                failure = True
+
+            for location in candidate.locations:
+                emit_annotation(level, location.file_path, location.line, f"[{source}] {candidate.value} -> {level}")
+
+        if output_file:
+            with output_file.open("w", encoding="utf-8") as fp:
+                json.dump(
+                    [
+                        {
+                            "value": candidate.value,
+                            "kind": candidate.kind,
+                            "locations": [hit.__dict__ for hit in candidate.locations],
+                            "result": result,
+                        }
+                        for candidate, result in scanned
+                    ],
+                    fp,
+                    indent=2,
+                )
+
+        if sarif_file:
+            sarif_payload = build_sarif_run(source, scanned)
+            with sarif_file.open("w", encoding="utf-8") as fp:
+                json.dump(sarif_payload, fp, indent=2)
+
+        if failure:
+            click.echo("❌ Threats detected - failing job.", err=True)
+            sys.exit(1)
+
+        click.echo("✅ No threats detected.")
+        sys.exit(0)
+
+    if not target:
+        click.echo(error_messages["missing_target"], err=True)
+        raise click.BadParameter(error_messages["missing_target"])
+
+    result = check.run(target, api_key=api_key or "")
 
     if "error" in result:
         logger.error(f"Error encountered: {result['error']}")

--- a/network_reputation_check/sarif.py
+++ b/network_reputation_check/sarif.py
@@ -1,0 +1,93 @@
+"""SARIF output helpers for reputation scan findings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from network_reputation_check.scanner import IndicatorCandidate
+
+SARIF_VERSION = "2.1.0"
+
+
+def classify_level(result: dict[str, Any]) -> str:
+    """Map a source result to SARIF level."""
+    stats = result.get("stats", {})
+    malicious = int(stats.get("malicious", 0))
+    suspicious = int(stats.get("suspicious", 0))
+    harmless = int(stats.get("harmless", 0))
+
+    if malicious > 0:
+        return "error"
+    if suspicious > 0:
+        return "warning"
+    if harmless > 0 or result.get("results"):
+        return "note"
+    return "warning"
+
+
+def _result_message(level: str, source: str, indicator: IndicatorCandidate, result: dict[str, Any]) -> str:
+    stats = result.get("stats", {})
+    return (
+        f"{source} check for {indicator.kind} '{indicator.value}' => {level}. "
+        f"stats={stats if stats else 'n/a'}"
+    )
+
+
+def build_sarif_run(source: str, scanned: list[tuple[IndicatorCandidate, dict[str, Any]]]) -> dict[str, Any]:
+    """Build a SARIF JSON document for all scanned indicators."""
+    results: list[dict[str, Any]] = []
+    rules: dict[str, dict[str, Any]] = {}
+
+    for indicator, check_result in scanned:
+        if check_result.get("error"):
+            level = "warning"
+            rule_id = f"{source}-lookup-error"
+            message = f"Lookup error for {indicator.value}: {check_result['error']}"
+        else:
+            level = classify_level(check_result)
+            rule_id = f"{source}-{level}"
+            message = _result_message(level, source, indicator, check_result)
+
+        rules.setdefault(
+            rule_id,
+            {
+                "id": rule_id,
+                "name": rule_id,
+                "shortDescription": {"text": f"{source} reputation result: {level}"},
+            },
+        )
+
+        results.extend(
+            {
+                "ruleId": rule_id,
+                "level": level,
+                "message": {"text": message},
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": location.file_path},
+                            "region": {"startLine": location.line},
+                        },
+                    },
+                ],
+            }
+            for location in indicator.locations
+        )
+
+    return {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "network-reputation-check",
+                        "informationUri": "https://github.com/ig596/network_reputation_checks",
+                        "rules": list(rules.values()),
+                    },
+                },
+                "results": results,
+            },
+        ],
+    }

--- a/network_reputation_check/scanner.py
+++ b/network_reputation_check/scanner.py
@@ -1,0 +1,161 @@
+"""Codebase indicator discovery utilities."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from network_reputation_check.utils import is_cidr, is_domain, is_ip
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+IP_PATTERN = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+CIDR_PATTERN = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}/(?:[0-9]|[1-2][0-9]|3[0-2])\b")
+DOMAIN_PATTERN = re.compile(r"\b(?:[A-Za-z0-9-]{1,63}\.)+[A-Za-z0-9-]{2,63}\b")
+
+SKIP_DIRS = {".git", ".venv", "venv", "node_modules", "dist", "build", "__pycache__"}
+MAX_SCAN_FILE_SIZE_BYTES = 1_000_000
+RESERVED_DOMAIN_SUFFIXES = {
+    ".alt",
+    ".arpa",
+    ".example",
+    ".home",
+    ".internal",
+    ".invalid",
+    ".lan",
+    ".local",
+    ".localhost",
+    ".localdomain",
+    ".test",
+}
+
+
+@dataclass(frozen=True)
+class IndicatorHit:
+    """An indicator discovered in a repository file."""
+
+    value: str
+    kind: str
+    file_path: str
+    line: int
+
+
+@dataclass(frozen=True)
+class IndicatorCandidate:
+    """A deduplicated indicator with all source locations."""
+
+    value: str
+    kind: str
+    locations: tuple[IndicatorHit, ...]
+
+
+def sanitize_indicator_value(value: str) -> str:
+    """Normalize an extracted indicator token before validation."""
+    return value.strip().strip("\"'()[]{}<>,;").replace("\r", "").replace("\n", "").replace("\t", "")
+
+
+def _is_public_ip(value: str) -> bool:
+    ip = ipaddress.ip_address(value)
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _is_public_cidr(value: str) -> bool:
+    net = ipaddress.ip_network(value, strict=False)
+    return not (
+        net.is_private
+        or net.is_loopback
+        or net.is_link_local
+        or net.is_multicast
+        or net.is_reserved
+        or net.is_unspecified
+    )
+
+
+def should_scan_indicator(value: str) -> bool:
+    """Return whether the indicator should be sent to reputation checks."""
+    if is_ip(value):
+        return _is_public_ip(value)
+    if "/" in value and is_cidr(value):
+        return _is_public_cidr(value)
+    if is_domain(value):
+        labels = value.split(".")
+        if all(label.isdigit() for label in labels):
+            return False
+        lowered = value.lower()
+        if lowered in {"localhost", "example.com", "example.org", "example.net"}:
+            return False
+        return not any(lowered.endswith(suffix) for suffix in RESERVED_DOMAIN_SUFFIXES)
+    return False
+
+
+def _iter_files(scan_root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in scan_root.rglob("*"):
+        if path.is_dir() and path.name in SKIP_DIRS:
+            continue
+        if not path.is_file():
+            continue
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if path.stat().st_size > MAX_SCAN_FILE_SIZE_BYTES:
+            continue
+        files.append(path)
+    return files
+
+
+def discover_indicators(scan_root: Path) -> list[IndicatorCandidate]:  # noqa: C901
+    """Discover IP/domain/CIDR indicators from text files in `scan_root`."""
+    hits: dict[tuple[str, str], list[IndicatorHit]] = {}
+
+    for file_path in _iter_files(scan_root):
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        relative = str(file_path.relative_to(scan_root))
+        for line_no, line in enumerate(content.splitlines(), start=1):
+            raw_values: set[str] = set(CIDR_PATTERN.findall(line))
+            raw_values.update(IP_PATTERN.findall(line))
+            raw_values.update(DOMAIN_PATTERN.findall(line))
+
+            for raw_value in raw_values:
+                value = sanitize_indicator_value(raw_value)
+                if not value:
+                    continue
+                kind = ""
+                if is_ip(value):
+                    kind = "ip"
+                elif "/" in value and is_cidr(value):
+                    kind = "cidr"
+                elif is_domain(value):
+                    labels = value.split(".")
+                    if all(label.isdigit() for label in labels):
+                        continue
+                    kind = "domain"
+                if not kind or not should_scan_indicator(value):
+                    continue
+
+                key = (value, kind)
+                hits.setdefault(key, []).append(
+                    IndicatorHit(value=value, kind=kind, file_path=relative, line=line_no),
+                )
+
+    return [
+        IndicatorCandidate(
+            value=value,
+            kind=kind,
+            locations=tuple(sorted(locations, key=lambda h: (h.file_path, h.line))),
+        )
+        for (value, kind), locations in sorted(hits.items(), key=lambda item: item[0][0])
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,12 @@
 """Tests for the CLI of the network reputation check tool."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
-from network_reputation_check.main import cli
+from network_reputation_check.main import _escape_workflow_command_value, cli
 
 
 @pytest.mark.parametrize(
@@ -106,6 +107,49 @@ def test_cli_invalid_source() -> None:
 def test_cli_missing_target() -> None:
     """Test the CLI with a missing target argument."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["--source", "virustotal"])
-    assert "Error: Missing argument 'TARGET'" in result.output
+    result = runner.invoke(cli, ["--source", "virustotal", "--api-key", "FAKE"])
+    assert "Error: Target is required unless --scan-path is provided." in result.output
     assert result.exit_code != 0
+
+
+@patch("network_reputation_check.checks.virus_total.VirusTotalCheck.run")
+def test_cli_scan_mode_writes_sarif(mock_run: MagicMock, tmp_path: Path) -> None:
+    """Test scan mode creates SARIF and succeeds for benign findings."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("ip = '8.8.8.8'\n", encoding="utf-8")
+    sarif = tmp_path / "out.sarif"
+
+    mock_run.return_value = {"stats": {"malicious": 0, "suspicious": 0, "harmless": 1}}
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--source",
+            "virustotal",
+            "--api-key",
+            "FAKE_VT_KEY",
+            "--scan-path",
+            str(repo),
+            "--sarif-file",
+            str(sarif),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert sarif.exists()
+
+
+def test_cli_rejects_target_with_control_chars() -> None:
+    """Test sanitization of user-provided target input."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["bad\r\ntarget", "--source", "virustotal", "--api-key", "FAKE"])
+    assert "Target contains invalid control characters" in result.output
+    assert result.exit_code != 0
+
+
+def test_escape_workflow_command_value() -> None:
+    """Ensure workflow command values are escaped for safety."""
+    escaped = _escape_workflow_command_value("file%name\r\ntext")
+    assert escaped == "file%25name%0D%0Atext"

--- a/tests/test_scanner_and_sarif.py
+++ b/tests/test_scanner_and_sarif.py
@@ -1,0 +1,101 @@
+"""Tests for indicator scanning and SARIF generation."""
+
+import json
+from pathlib import Path
+
+from network_reputation_check.sarif import build_sarif_run, classify_level
+from network_reputation_check.scanner import (
+    IndicatorCandidate,
+    IndicatorHit,
+    discover_indicators,
+    sanitize_indicator_value,
+)
+
+
+def test_discover_indicators_filters_non_public(tmp_path: Path) -> None:
+    """Ensure scanner extracts public indicators and skips local-only values."""
+    sample = tmp_path / "sample.txt"
+    sample.write_text(
+        "connect to 8.8.8.8 and example.com\n"
+        "internal 10.0.0.1 localhost app.local app.internal 192.168.0.0/16\n"
+        "range 8.8.8.0/24 and domain bad.example.org\n",
+        encoding="utf-8",
+    )
+
+    found = discover_indicators(tmp_path)
+    values = {(item.value, item.kind) for item in found}
+
+    assert ("8.8.8.8", "ip") in values
+    assert ("8.8.8.0/24", "cidr") in values
+    assert ("bad.example.org", "domain") in values
+    assert ("10.0.0.1", "ip") not in values
+    assert ("example.com", "domain") not in values
+    assert ("app.local", "domain") not in values
+    assert ("app.internal", "domain") not in values
+
+
+def test_sarif_levels_and_payload() -> None:
+    """Ensure SARIF payload emits the expected severity levels."""
+    indicator = IndicatorCandidate(
+        value="evil.example",
+        kind="domain",
+        locations=(IndicatorHit(value="evil.example", kind="domain", file_path="a.txt", line=3),),
+    )
+
+    payload = build_sarif_run(
+        "virustotal",
+        [
+            (indicator, {"stats": {"malicious": 2, "suspicious": 0}}),
+            (indicator, {"stats": {"malicious": 0, "suspicious": 1}}),
+            (indicator, {"stats": {"malicious": 0, "suspicious": 0, "harmless": 42}}),
+        ],
+    )
+
+    result_levels = [item["level"] for item in payload["runs"][0]["results"]]
+    assert "error" in result_levels
+    assert "warning" in result_levels
+    assert "note" in result_levels
+
+    assert classify_level({"stats": {"malicious": 1}}) == "error"
+    assert classify_level({"stats": {"suspicious": 1}}) == "warning"
+    assert classify_level({"stats": {"harmless": 1}}) == "note"
+
+    json.dumps(payload)
+
+
+def test_sanitize_indicator_value_strips_wrappers_and_crlf() -> None:
+    """Ensure extracted indicators are normalized safely."""
+    assert sanitize_indicator_value("('8.8.8.8')\r\n") == "8.8.8.8"
+
+
+def test_review_examples_include_good_and_bad_indicators(tmp_path: Path) -> None:
+    """Include explicit review examples for benign/suspicious-looking indicators."""
+    good_ip = "1.1.1.1"
+    bad_ip_for_review = "45.9.148.108"
+    good_domain = "cloudflare.com"
+    bad_domain_for_review = "malicious-example.net"
+    good_cidr = "8.8.4.0/24"
+    bad_cidr_for_review = "185.220.100.0/24"
+
+    sample = tmp_path / "review_examples.txt"
+    sample.write_text(
+        (
+            f"good_ip={good_ip}\n"
+            f"bad_ip={bad_ip_for_review}\n"
+            f"good_domain={good_domain}\n"
+            f"bad_domain={bad_domain_for_review}\n"
+            f"good_cidr={good_cidr}\n"
+            f"bad_cidr={bad_cidr_for_review}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    found = discover_indicators(tmp_path)
+    values = {(item.value, item.kind) for item in found}
+
+    assert (good_ip, "ip") in values
+    assert (bad_ip_for_review, "ip") in values
+    assert (good_domain, "domain") in values
+    assert (bad_domain_for_review, "domain") in values
+    assert (good_cidr, "cidr") in values
+    assert (bad_cidr_for_review, "cidr") in values


### PR DESCRIPTION
### Motivation
- Enable repository scanning to auto-discover IP/domain/CIDR indicators and produce SARIF for GitHub Code Scanning and PR annotations.
- Emit safe workflow annotations and normalize inputs to prevent injection and invalid control characters.
- Make CI less intrusive by restricting permissions and removing automated commit pushes for badges and pre-commit fixes.

### Description
- Add `network_reputation_check/scanner.py` to discover, normalize, deduplicate, and filter public indicators from a repository path and add `network_reputation_check/sarif.py` to build SARIF payloads and classify severity levels.
- Extend the CLI (`network_reputation_check/main.py`) with `--scan-path` and `--sarif-file` options, a `sanitize_target` helper, `_escape_workflow_command_value` and `emit_annotation` to write safe GitHub Actions annotations, and flow to run checks across discovered indicators with JSON and SARIF output support.
- Update `action.yml` and `README.md` to expose optional `scan-path`, `sarif-file`, and `output-file` inputs and make `target` optional when scan mode is used, and wire inputs into the Docker action args.
- Adjust workflows: tighten permissions in `ci.yaml`, stop committing coverage/pre-commit changes from CI and instead upload the coverage badge as an artifact, and enhance `run-reputation-check.yaml` with `scan-path`/`sarif-file` inputs and SARIF upload step.

### Testing
- Ran unit tests with `poetry run pytest`, including updated `tests/test_cli.py` and new `tests/test_scanner_and_sarif.py`, and all tests succeeded.
- Test suite included CLI behavior checks (scan mode, target sanitization, workflow-escaping) and scanner/SARIF validations (indicator discovery, filtering, level classification, and payload serialization).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec109a567c83308cc6996edb34effd)